### PR TITLE
REMOVE overly-intrusive checks from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,8 @@ Checks: "*,
         -readability-avoid-const-params-in-decls,
         -cppcoreguidelines-non-private-member-variables-in-classes,
         -misc-non-private-member-variables-in-classes,
+	-bugprone-easily-swappable-parameters,
+	-readability-identifier-length,
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 out/
 cmake-build-*/
+Testing/
 
 # User spesific settings
 CMakeUserPresets.json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,9 +12,9 @@ find_package(spdlog CONFIG REQUIRED)
 
 add_subdirectory(${PROJECT_NAME})
 
-add_executable(${PROJECT_NAME} main.cpp)
+add_executable(run_${PROJECT_NAME} main.cpp)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE
+target_link_libraries(run_${PROJECT_NAME} PRIVATE
   myproject_lib
   CLI11::CLI11
   fmt::fmt

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,10 +5,11 @@
 #include <cstring>
 #include <list>
 #include <sstream>
+#include <optional>
 
 #include "myproject/myproject.h"
 
-bool extract_command(float& a, float& b, char& c, const std::string& message)
+bool extract_command(float& a, float& b, char& op, const std::string& message)
 {
     try
     {
@@ -23,7 +24,7 @@ bool extract_command(float& a, float& b, char& c, const std::string& message)
                 (std::string("Supporting only single-character operators: ") + str).c_str());
             return false;
         }
-        c = str[0];
+        op = str[0];
         iss >> str;
         b = std::stof(str);
         return true;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,13 +8,13 @@ target_link_libraries(catch_main PUBLIC Catch2::Catch2)
 target_link_libraries(catch_main PRIVATE project_options)
 
 # Provide a simple smoke test to make sure that the CLI works and can display a --help message
-add_test(NAME cli.has_help COMMAND intro --help)
+add_test(NAME cli.has_help COMMAND run_${PROJECT_NAME} --help)
 
 # Provide a test to verify that the version being reported from the application
 # matches the version given to CMake. This will be important once you package
 # your program. Real world shows that this is the kind of simple mistake that is easy
 # to make, but also easy to test for.
-add_test(NAME cli.version_matches COMMAND run${PROJECT_NAME} --version)
+add_test(NAME cli.version_matches COMMAND run_${PROJECT_NAME} --version)
 set_tests_properties(cli.version_matches PROPERTIES PASS_REGULAR_EXPRESSION "${PROJECT_VERSION}")
 
 


### PR DESCRIPTION
A bunch of fixes that should help the ci PR